### PR TITLE
feat: release 2.4.1, release giokit 1.3.1

### DIFF
--- a/GrowingAnalytics/BuildProfile.ets
+++ b/GrowingAnalytics/BuildProfile.ets
@@ -1,7 +1,7 @@
 /**
  * Use these variables when you tailor your ArkTS code. They must be of the const type.
  */
-export const HAR_VERSION = '2.4.0';
+export const HAR_VERSION = '2.4.1';
 export const BUILD_MODE_NAME = 'release';
 export const DEBUG = false;
 export const TARGET_NAME = 'default';

--- a/GrowingAnalytics/CHANGELOG.md
+++ b/GrowingAnalytics/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.4.1](https://github.com/growingio/growingio-sdk-harmonyos/tree/2.4.1) (2025-08-28)
+
+### Bug Fixes 修复
+
+* fix: compatibleSdkVersion 降低为 API 12
+* fix: 添加 UseTsHar 标记，以适配 Sendable 的使用
+
 ## [2.4.0](https://github.com/growingio/growingio-sdk-harmonyos/tree/2.4.0) (2025-08-26)
 
 ### Features 功能

--- a/GrowingAnalytics/oh-package.json5
+++ b/GrowingAnalytics/oh-package.json5
@@ -13,7 +13,7 @@
   "main": "index.ets",
   "type": "module",
   "repository": "https://github.com/growingio/growingio-sdk-harmonyos",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "dependencies": {
     "snappyjs": "^0.7.0",
     "@ohos/protobufjs": "^2.1.0",

--- a/GrowingAnalytics/src/main/module.json5
+++ b/GrowingAnalytics/src/main/module.json5
@@ -7,6 +7,12 @@
       "tablet",
       "2in1"
     ],
+    "metadata": [
+      {
+        "name": "UseTsHar",
+        "value": "true"
+      }
+    ],
     "requestPermissions": [
       {
         "name": "ohos.permission.INTERNET"

--- a/GrowingToolsKit/BuildProfile.ets
+++ b/GrowingToolsKit/BuildProfile.ets
@@ -1,7 +1,7 @@
 /**
  * Use these variables when you tailor your ArkTS code. They must be of the const type.
  */
-export const HAR_VERSION = '1.3.0';
+export const HAR_VERSION = '1.3.1';
 export const BUILD_MODE_NAME = 'release';
 export const DEBUG = false;
 export const TARGET_NAME = 'default';

--- a/GrowingToolsKit/CHANGELOG.md
+++ b/GrowingToolsKit/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.3.1](https://github.com/growingio/growingio-sdk-harmonyos/tree/giokit-1.3.1) (2025-08-28)
+
+### Bug Fixes 修复
+
+* fix: 添加 UseTsHar 标记，以适配 Sendable 的使用
+
 ## [1.3.0](https://github.com/growingio/growingio-sdk-harmonyos/tree/giokit-1.3.0) (2025-08-26)
 
 ### Features 功能

--- a/GrowingToolsKit/oh-package.json5
+++ b/GrowingToolsKit/oh-package.json5
@@ -11,7 +11,7 @@
   "main": "Index.ets",
   "type": "module",
   "repository": "https://github.com/growingio/growingio-sdk-harmonyos",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "dependencies": {
     "snappyjs": "^0.7.0",
     "@ohos/protobufjs": "^2.1.0",

--- a/GrowingToolsKit/src/main/module.json5
+++ b/GrowingToolsKit/src/main/module.json5
@@ -6,6 +6,12 @@
       "default",
       "tablet",
       "2in1"
+    ],
+    "metadata": [
+      {
+        "name": "UseTsHar",
+        "value": "true"
+      }
     ]
   }
 }

--- a/build-profile.json5
+++ b/build-profile.json5
@@ -5,7 +5,7 @@
       {
         "name": "default",
         "signingConfig": "default",
-        "compatibleSdkVersion": "5.0.2(14)",
+        "compatibleSdkVersion": "5.0.0(12)",
         "runtimeOS": "HarmonyOS",
         "buildOption": {
           "strictMode": {


### PR DESCRIPTION
- 编译 GrowingAnalytics 时，应保证项目根目录下的 build-profile.json5 中 `compatibleSdkVersion` 为 `5.0.0(12)`，以最大化兼容 HarmonyOS 版本；
- 编译 GrowingToolsKit 时，则改为 `5.0.2(14)`

----

## [2.4.1](https://github.com/growingio/growingio-sdk-harmonyos/tree/2.4.1) (2025-08-28)

### Bug Fixes 修复

* fix: compatibleSdkVersion 降低为 API 12
* fix: 添加 UseTsHar 标记，以适配 Sendable 的使用

## [giokit-1.3.1](https://github.com/growingio/growingio-sdk-harmonyos/tree/giokit-1.3.1) (2025-08-28)

### Bug Fixes 修复

* fix: 添加 UseTsHar 标记，以适配 Sendable 的使用
