### PR TITLE
修复 Flutter PAGE 事件时间戳与 VIEW_CLICK pageShowTimestamp 不一致

### DIFF
--- a/GrowingAnalytics/src/main/ets/components/core/Flutter.ets
+++ b/GrowingAnalytics/src/main/ets/components/core/Flutter.ets
@@ -83,6 +83,10 @@ export class Flutter {
     let pageInfo = new PageInfo(path, title, attributes)
     pageInfo.referralPage = referralPage
     pageInfo.eventScene = EventScene.Flutter
+    let timestamp = argument.get('timestamp') as number
+    if (timestamp != null && timestamp != undefined && timestamp > 0) {
+      pageInfo.timestamp = timestamp
+    }
     AutotrackPage.sendPage(pageInfo)
   }
 


### PR DESCRIPTION
## 背景

CDP/SaaS 模式下，Flutter 页面的 PAGE 事件 `timestamp` 与同页 VIEW_CLICK 的 `pageShowTimestamp` 对不齐（实测偏差约几十 ms）。这会破坏 CDP 服务端「点击 → 页面浏览实例」的归因。

## 根因

Flutter（Dart）侧 `GrowingPageEvent.toNativeMap()` 已经把页面显示时间戳放进 `timestamp` 字段随 `trackFlutterPage` 上报，且该值与 click 的 `pageShowTimestamp` 同源（均取自 `currentPage.pageEvent.timestamp`）。

但 HarmonyOS 原生侧 `Flutter.trackFlutterPage` **未读取该字段**，`PageInfo.timestamp` 保持默认 0，随后被 `EventBuilder.build` 用原生 `Date.now()` 重新盖章——于是 PAGE 用的是「原生收到时刻」，click 用的是「Flutter 页面显示时刻」，两者相差一段跨 Platform Channel 的链路延迟。

## 改动

`Flutter.trackFlutterPage` 读取 `argument['timestamp']` 并赋给 `pageInfo.timestamp`：

- 有效正整数 → 使用它，使 PAGE 与 click 的 `pageShowTimestamp` 同源；
- 缺省时保持默认 0，由 `EventBuilder` 回退到 `Date.now()`，兼容不携带 timestamp 的旧版 Flutter SDK。

写法与同文件 `ptm`/`title`/`path` 的内联解析保持一致，仅 4 行。

## 影响范围

- 仅影响 Flutter 桥接的 PAGE 事件时间戳来源；原生/Hybrid/UniApp 路径不受影响。
- 对 NewSaaS 的 `FlutterPageEvent` 路径同样生效。

## 验证

- ✅ `GrowingAnalytics` HAR 构建通过（`BUILD SUCCESSFUL`）。
- ⏳ 建议在真机用 Flutter 示例复现，确认 PAGE.timestamp 与 VIEW_CLICK.pageShowTimestamp 一致。
- ⏳ 待核对 iOS 端 `trackFlutterPage` 的 timestamp 取值口径，保证多端一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)